### PR TITLE
Commande mode: Add catch and show error in result

### DIFF
--- a/src/views/consolePane/commandMode.vue
+++ b/src/views/consolePane/commandMode.vue
@@ -77,11 +77,18 @@ const handleRun = async () => {
 
   const commandArr = await handleCommandFormat(key)
 
-  const res = await client.sendCommand(commandArr)
+  const res = await client.sendCommand(commandArr).catch((err) => {
+    const { name, message } = err
+    return { error: { name, message } }
+  })
+
   if (!res || res === [] || res.length === 0) {
     results.push('nil')
   } else {
-    if (typeof res === 'string') {
+    if (res.error) {
+      const { name, message } = res.error
+      results.push(`${name}: ${message}`)
+    } else if (typeof res === 'string') {
       results.push(res)
     } else {
       results = res


### PR DESCRIPTION
I discovered this issue where if you enter a bad command, there is an unhandled error thrown. 

This prevents other commands to be run, and it's not showing the error to the user. 

The fix proposed is catching the error and just printing the error name and message. Other commands can be sent afterwards